### PR TITLE
ci: add github action

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   test:
-    name: build
+    name: build-publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -11,3 +11,9 @@ jobs:
       - run: yarn install
 
       - run: yarn build
+
+      - name: semantic-release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,0 +1,13 @@
+name: build-publish
+on: [push]
+
+jobs:
+  test:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: yarn install
+
+      - run: yarn build


### PR DESCRIPTION
### What this PR is about:

- Adds a GitHub action that builds the project on every push and
- Publishes the library using semantic-release if it's on a branch that should be published