### PR TITLE
feat: allow validation of subfields

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const schema = makeSchema({
 
 ## Usage
 
-Validation can be added to the types `Query` and `Mutation` and will validate the `args` passed in when a request is made:
+The `validate` method can be added to any field with `args`:
 
 ```ts
 const UserMutation = extendType({

--- a/examples/hello-world/schema.graphql
+++ b/examples/hello-world/schema.graphql
@@ -7,12 +7,13 @@ type Mutation {
 }
 
 type Query {
-  ok: Boolean!
+  user(email: String): User
 }
 
 type User {
   age: Int
   email: String
+  friends(email: String): [User]
   name: String
   secret: String
   website: String

--- a/examples/hello-world/src/generated/nexus.ts
+++ b/examples/hello-world/src/generated/nexus.ts
@@ -55,11 +55,12 @@ export interface NexusGenFieldTypes {
     createUser: NexusGenRootTypes['User'] | null; // User
   }
   Query: { // field return type
-    ok: boolean; // Boolean!
+    user: NexusGenRootTypes['User'] | null; // User
   }
   User: { // field return type
     age: number | null; // Int
     email: string | null; // String
+    friends: Array<NexusGenRootTypes['User'] | null> | null; // [User]
     name: string | null; // String
     secret: string | null; // String
     website: string | null; // String
@@ -71,11 +72,12 @@ export interface NexusGenFieldTypeNames {
     createUser: 'User'
   }
   Query: { // field return type name
-    ok: 'Boolean'
+    user: 'User'
   }
   User: { // field return type name
     age: 'Int'
     email: 'String'
+    friends: 'User'
     name: 'String'
     secret: 'String'
     website: 'String'
@@ -90,6 +92,16 @@ export interface NexusGenArgTypes {
       name?: string | null; // String
       secret?: string | null; // String
       website?: string | null; // String
+    }
+  }
+  Query: {
+    user: { // args
+      email?: string | null; // String
+    }
+  }
+  User: {
+    friends: { // args
+      email?: string | null; // String
     }
   }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -47,10 +47,11 @@ export const resolver = (validateConfig: ValidatePluginConfig = {}) => (
     return;
   }
 
-  if (['Mutation', 'Query'].indexOf(config.parentTypeConfig.name) === -1) {
-    console.warn(
+  const args = config?.fieldConfig?.args ?? {};
+  if (Object.keys(args).length === 0) {
+    console.error(
       '\x1b[33m%s\x1b[0m',
-      `The validate property was provided to [${config.fieldConfig.name}] with parent [${config.parentTypeConfig.name}]. Should have parent [Query] or [Mutation].`
+      `[${config.parentTypeConfig.name}.${config.fieldConfig.name}] does not have any arguments, but a validate function was passed`
     );
   }
 

--- a/tests/__snapshots__/validate-fn.test.ts.snap
+++ b/tests/__snapshots__/validate-fn.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validatePlugin warns if validate is added in an invalid way 1`] = `
+exports[`validatePlugin warns if field are missing arguments 1`] = `
 Array [
   "[33m%s[0m",
-  "The validate property was provided to [id] with parent [ShouldWarn]. Should have parent [Query] or [Mutation].",
+  "[ShouldWarn.id] does not have any arguments, but a validate function was passed",
 ]
 `;
 
-exports[`validatePlugin warns if validate is added in an invalid way 2`] = `
+exports[`validatePlugin warns if validate is not a function 1`] = `
 Array [
   "[33m%s[0m",
   "The validate property provided to [shouldWarn] with type [ShouldWarn!]. Should be a function, saw [object]",


### PR DESCRIPTION
### What this PR is about:

There's currently a constraint that the `validate` method can only be added to a field with `Query` or `Mutation` as parent. This is bad, because a query can look like this:

```graphql
{
  users(email: "test@test.com") {
    id
    friends(filter: { email: "friend@email.com" }) {
      id
    }
  }
}
```

This PR removes the constraint and adds a new one: you can now only pass the `validate` method to a field that has `args`.