### PR TITLE
feat: add support for generic validations through input objects

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "apollo-server": "^2.19.2",
-    "graphql": "^15.4.0",
-    "nexus": "^1.0.0",
-    "nexus-validate": "1.0.0-alpha.4",
-    "yup": "^0.32.8"
+    "graphql": "^15.5.3",
+    "nexus": "^1.1.0",
+    "nexus-validate": "^1.0.0",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "ts-node": "^9.1.1",

--- a/examples/hello-world/schema.graphql
+++ b/examples/hello-world/schema.graphql
@@ -13,8 +13,12 @@ type Query {
 type User {
   age: Int
   email: String
-  friends(email: String): [User]
+  friends(query: UserInput): [User]
   name: String
   secret: String
   website: String
+}
+
+input UserInput {
+  email: String
 }

--- a/examples/hello-world/schema.graphql
+++ b/examples/hello-world/schema.graphql
@@ -2,6 +2,10 @@
 ### Do not make changes to this file directly
 
 
+input FilterInput {
+  sort: String
+}
+
 type Mutation {
   createUser(age: Int, email: String, name: String, secret: String, website: String): User
 }
@@ -13,7 +17,7 @@ type Query {
 type User {
   age: Int
   email: String
-  friends(query: UserInput): [User]
+  friends(filter: FilterInput, query: UserInput): [User]
   name: String
   secret: String
   website: String

--- a/examples/hello-world/src/generated/nexus.ts
+++ b/examples/hello-world/src/generated/nexus.ts
@@ -5,7 +5,7 @@
 
 
 import type { Context } from "./../context"
-import type { ValidateResolver } from "nexus-validate"
+import type { ValidateResolver, InputObjectValidateResolver } from "nexus-validate"
 
 
 
@@ -15,6 +15,9 @@ declare global {
 }
 
 export interface NexusGenInputs {
+  FilterInput: { // input type
+    sort?: string | null; // String
+  }
   UserInput: { // input type
     email?: string | null; // String
   }
@@ -104,6 +107,7 @@ export interface NexusGenArgTypes {
   }
   User: {
     friends: { // args
+      filter?: NexusGenInputs['FilterInput'] | null; // FilterInput
       query?: NexusGenInputs['UserInput'] | null; // UserInput
     }
   }
@@ -170,6 +174,10 @@ declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
   }
   interface NexusGenPluginInputTypeConfig<TypeName extends string> {
+    /**
+     * Validate mutation arguments.
+     */
+    validate?: InputObjectValidateResolver
   }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
     /**

--- a/examples/hello-world/src/generated/nexus.ts
+++ b/examples/hello-world/src/generated/nexus.ts
@@ -4,8 +4,8 @@
  */
 
 
-import { Context } from "./../context"
-import { ValidateResolver } from "nexus-validate"
+import type { Context } from "./../context"
+import type { ValidateResolver } from "nexus-validate"
 
 
 
@@ -165,6 +165,8 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
+  }
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
   }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
     /**

--- a/examples/hello-world/src/generated/nexus.ts
+++ b/examples/hello-world/src/generated/nexus.ts
@@ -15,6 +15,9 @@ declare global {
 }
 
 export interface NexusGenInputs {
+  UserInput: { // input type
+    email?: string | null; // String
+  }
 }
 
 export interface NexusGenEnums {
@@ -101,7 +104,7 @@ export interface NexusGenArgTypes {
   }
   User: {
     friends: { // args
-      email?: string | null; // String
+      query?: NexusGenInputs['UserInput'] | null; // UserInput
     }
   }
 }
@@ -114,7 +117,7 @@ export interface NexusGenTypeInterfaces {
 
 export type NexusGenObjectNames = keyof NexusGenObjects;
 
-export type NexusGenInputNames = never;
+export type NexusGenInputNames = keyof NexusGenInputs;
 
 export type NexusGenEnumNames = never;
 

--- a/examples/hello-world/src/schema.ts
+++ b/examples/hello-world/src/schema.ts
@@ -56,8 +56,8 @@ const Mutation = mutationType({
       // the rules from the first argument together with args and context
       // to figure out if the provided arguments are valid or not
       validate: ({ string, number }, args, ctx) => ({
-        name: string(),
-        email: string().email(),
+        name: string().trim(),
+        email: string().email().trim(),
         age: number().min(18),
         website: string().url(),
         // create a custom rule for secret that uses a custom test,

--- a/examples/hello-world/src/schema.ts
+++ b/examples/hello-world/src/schema.ts
@@ -24,11 +24,7 @@ export const User = objectType({
     t.string('name');
     t.string('email');
     t.int('age');
-    t.string('website', {
-      validate: ({ string }) => ({
-        website: string().email().required(),
-      }),
-    });
+    t.string('website');
     t.string('secret');
     t.list.field('friends', {
       type: User,

--- a/examples/hello-world/src/schema.ts
+++ b/examples/hello-world/src/schema.ts
@@ -25,9 +25,19 @@ export const UserInput = inputObjectType({
   definition(t) {
     t.string('email');
   },
-  // @ts-ignore requires https://github.com/graphql-nexus/nexus/pull/799
   validate: ({ string }) => ({
-    email: string().email().required(),
+    // this is made required in the other validate below
+    email: string().email(),
+  }),
+});
+
+export const FilterInput = inputObjectType({
+  name: 'FilterInput',
+  definition(t) {
+    t.string('sort');
+  },
+  validate: ({ string }) => ({
+    sort: string().oneOf(['desc', 'asc']),
   }),
 });
 
@@ -45,7 +55,15 @@ export const User = objectType({
         query: arg({
           type: UserInput,
         }),
+        filter: arg({
+          type: FilterInput,
+        }),
       },
+      validate: ({ string, object }) => ({
+        query: object({
+          email: string().required(),
+        }),
+      }),
       resolve: (_, args) => {
         return USERS;
       },

--- a/examples/hello-world/src/schema.ts
+++ b/examples/hello-world/src/schema.ts
@@ -5,6 +5,8 @@ import {
   objectType,
   intArg,
   queryType,
+  inputObjectType,
+  arg,
 } from 'nexus';
 import { validatePlugin, ValidationError } from 'nexus-validate';
 import { UserInputError } from 'apollo-server';
@@ -18,26 +20,32 @@ let USERS = [
   },
 ];
 
+export const UserInput = inputObjectType({
+  name: 'UserInput',
+  definition(t) {
+    t.string('email');
+  },
+  // @ts-ignore requires https://github.com/graphql-nexus/nexus/pull/799
+  validate: ({ string }) => ({
+    email: string().email().required(),
+  }),
+});
+
 export const User = objectType({
   name: 'User',
   definition(t) {
     t.string('name');
     t.string('email');
     t.int('age');
-    t.string('website', {
-      validate: ({ string }) => ({
-        website: string().email().required(),
-      }),
-    });
+    t.string('website');
     t.string('secret');
     t.list.field('friends', {
       type: User,
       args: {
-        email: stringArg(),
+        query: arg({
+          type: UserInput,
+        }),
       },
-      validate: ({ string }) => ({
-        email: string().email(),
-      }),
       resolve: (_, args) => {
         return USERS;
       },

--- a/examples/hello-world/yarn.lock
+++ b/examples/hello-world/yarn.lock
@@ -1014,10 +1014,15 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-graphql@^15.3.0, graphql@^15.4.0:
+graphql@^15.3.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
+
+graphql@^15.5.3:
+  version "15.5.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.3.tgz#c72349017d5c9f5446a897fe6908b3186db1da00"
+  integrity sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==
 
 has-symbols@^1.0.1:
   version "1.0.1"
@@ -1197,10 +1202,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-lodash-es@^4.17.11:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
-  integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
+lodash-es@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -1332,15 +1337,15 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-nexus-validate@1.0.0-alpha.4:
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/nexus-validate/-/nexus-validate-1.0.0-alpha.4.tgz#ba85de73f44f046e52e05e5e4f7efbe6c1f1e596"
-  integrity sha512-X1rxGyL4C14luEBdGclVROztZqEuyybhLnnDmIePSuPShMLOxKbNSqxG2bn/vtlVhp9sjtqHXRPZ/8r6AIIx+g==
-
-nexus@^1.0.0:
+nexus-validate@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/nexus/-/nexus-1.0.0.tgz#633b39abae1d7e9472ca40e37bb5d3e1263f6aa3"
-  integrity sha512-Toa91s9BJsX8pDX34QkOyKdnw8MmuOQkEboZMKSxvF9mWuAFkY74Zj1ssaexeV7yTQ7HoLQYUQ00FaWzXPmggQ==
+  resolved "https://registry.yarnpkg.com/nexus-validate/-/nexus-validate-1.0.0.tgz#2bb2291cecb7a3909b647b75fde1ab666ba39b95"
+  integrity sha512-wmshQH2etCIgZoIMCQeEXCrMPx+LknUhUFrVyfezJvnpO5c4MPBLlQQQQJ4VYn0cLRCckU+Pof290jVleVxSuw==
+
+nexus@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nexus/-/nexus-1.1.0.tgz#3d8fa05c29e7a61aa55f64ef5e0ba43dd76b3ed6"
+  integrity sha512-jUhbg22gKVY2YwZm726BrbfHaQ7Xzc0hNXklygDhuqaVxCuHCgFMhWa2svNWd1npe8kfeiu5nbwnz+UnhNXzCQ==
   dependencies:
     iterall "^1.3.0"
     tslib "^2.0.3"
@@ -1939,15 +1944,15 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-yup@^0.32.8:
-  version "0.32.8"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.8.tgz#16e4a949a86a69505abf99fd0941305ac9adfc39"
-  integrity sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==
+yup@^0.32.9:
+  version "0.32.9"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.9.tgz#9367bec6b1b0e39211ecbca598702e106019d872"
+  integrity sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==
   dependencies:
     "@babel/runtime" "^7.10.5"
     "@types/lodash" "^4.14.165"
     lodash "^4.17.20"
-    lodash-es "^4.17.11"
+    lodash-es "^4.17.15"
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "graphql": "^15.4.0",
-    "nexus": "^1.0.0",
-    "yup": "^0.32.8"
+    "graphql": "^15.x",
+    "nexus": "^1.1.0",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { plugin } from 'nexus';
-import { printedGenTyping, printedGenTypingImport } from 'nexus/dist/core';
+import { printedGenTyping, printedGenTypingImport } from 'nexus/dist/utils';
 
 import { ValidatePluginErrorConfig, ValidationError } from './error';
 import { resolver } from './resolver';

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -5,6 +5,7 @@ import {
   MaybePromise,
   MiddlewareFn,
 } from 'nexus/dist/core';
+import { ValidationError } from 'yup';
 
 import { ObjectShape, rules, ValidationRules } from './rules';
 import { ValidatePluginConfig } from './index';
@@ -63,7 +64,8 @@ export const resolver = (validateConfig: ValidatePluginConfig = {}) => (
         await schema.validate(args);
       }
       return next(root, args, ctx, info);
-    } catch (error) {
+    } catch (_error) {
+      const error = _error as Error | ValidationError
       throw formatError({ error, args, ctx });
     }
   };

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -20,53 +20,56 @@ export type ValidateResolver<
   ctx: GetGen<'context'>
 ) => MaybePromise<ObjectShape | void>;
 
-export const resolver = (validateConfig: ValidatePluginConfig = {}) => (
-  config: CreateFieldResolverInfo
-): MiddlewareFn | undefined => {
-  const { formatError = defaultFormatError } = validateConfig;
+export const resolver =
+  (validateConfig: ValidatePluginConfig = {}) =>
+  (config: CreateFieldResolverInfo): MiddlewareFn | undefined => {
+    const { formatError = defaultFormatError } = validateConfig;
 
-  const validate: ValidateResolver<any, any> =
-    config.fieldConfig.extensions?.nexus?.config.validate;
+    const validate: ValidateResolver<any, any> =
+      config.fieldConfig.extensions?.nexus?.config.validate;
 
-  // if the field doesn't have an validate field,
-  // don't worry about wrapping the resolver
-  if (validate == null) {
-    return;
-  }
-
-  // if it does have this field, but it's not a function,
-  // it's wrong - let's provide a warning
-  if (typeof validate !== 'function') {
-    console.error(
-      '\x1b[33m%s\x1b[0m',
-      `The validate property provided to [${
-        config.fieldConfig.name
-      }] with type [${
-        config.fieldConfig.type
-      }]. Should be a function, saw [${typeof validate}]`
-    );
-    return;
-  }
-
-  const args = config?.fieldConfig?.args ?? {};
-  if (Object.keys(args).length === 0) {
-    console.error(
-      '\x1b[33m%s\x1b[0m',
-      `[${config.parentTypeConfig.name}.${config.fieldConfig.name}] does not have any arguments, but a validate function was passed`
-    );
-  }
-
-  return async (root, args, ctx, info, next) => {
-    try {
-      const schemaBase = await validate(rules, args, ctx);
-      if (typeof schemaBase !== 'undefined') {
-        const schema = rules.object().shape(schemaBase);
-        await schema.validate(args);
-      }
-      return next(root, args, ctx, info);
-    } catch (_error) {
-      const error = _error as Error | ValidationError
-      throw formatError({ error, args, ctx });
+    // if the field doesn't have an validate field,
+    // don't worry about wrapping the resolver
+    if (validate == null) {
+      return;
     }
+
+    // if it does have this field, but it's not a function,
+    // it's wrong - let's provide a warning
+    if (typeof validate !== 'function') {
+      console.error(
+        '\x1b[33m%s\x1b[0m',
+        `The validate property provided to [${
+          config.fieldConfig.name
+        }] with type [${
+          config.fieldConfig.type
+        }]. Should be a function, saw [${typeof validate}]`
+      );
+      return;
+    }
+
+    const args = config?.fieldConfig?.args ?? {};
+    if (Object.keys(args).length === 0) {
+      console.error(
+        '\x1b[33m%s\x1b[0m',
+        `[${config.parentTypeConfig.name}.${config.fieldConfig.name}] does not have any arguments, but a validate function was passed`
+      );
+    }
+
+    return async (root, rawArgs, ctx, info, next) => {
+      try {
+        const schemaBase = await validate(rules, rawArgs, ctx);
+        // clone args so we can transform them when validating with yup
+        let args = { ...rawArgs };
+        if (typeof schemaBase !== 'undefined') {
+          const schema = rules.object().shape(schemaBase);
+          // update args to the transformed ones by yup
+          args = await schema.validate(args);
+        }
+        return next(root, args, ctx, info);
+      } catch (_error) {
+        const error = _error as Error | ValidationError;
+        throw formatError({ error, args, ctx });
+      }
+    };
   };
-};

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -19,6 +19,10 @@ export type ValidateResolver<
   ctx: GetGen<'context'>
 ) => MaybePromise<ObjectShape | void>;
 
+export type InputObjectValidateResolver = (
+  rules: ValidationRules
+) => ObjectShape;
+
 export const resolver = (validateConfig: ValidatePluginConfig = {}) => (
   config: CreateFieldResolverInfo
 ): MiddlewareFn | undefined => {

--- a/tests/validate-fn.test.ts
+++ b/tests/validate-fn.test.ts
@@ -1,6 +1,7 @@
 import { graphql } from 'graphql';
 import { makeSchema, objectType } from 'nexus';
 import { floatArg, intArg, mutationField, stringArg } from 'nexus/dist/core';
+
 import { UserInputError, validatePlugin } from '../src/index';
 
 describe('validatePlugin', () => {


### PR DESCRIPTION
### What this PR is about

Adds support for generic validations through `inputObjectType`. The `validate` method here needs to return a function that returns an `ObjectShape` instead of a function, because we can't pass args and context here:

```ts
export const UserInput = inputObjectType({
  name: 'UserInput',
  definition(t) {
    t.string('email');
  },
  validate: ({ string }) => ({
    email: string().email().required(),
  }),
});
```

This will then get called whenever `UserInput` is used.

### Work left to do

A field currently only support one validation function, and since yup schemas can't be merged we will need to support passing an array of validation functions so we can call all of them. Today, this scenario wouldn't work:

```ts
t.list.field('friends', {
  type: User,
  args: {
    name: stringArg(),
    query: arg({
      type: UserInput,
    }),
  },
  // this would be overwritten by the validation in UserInput
  validate: ({ string }) => ({ name: string().min(10) }),
});
```

The idea is that our resolver should be able to run both validations.

### Blockers

The implementation works, but the types are currently broken and needs this PR to work: https://github.com/graphql-nexus/nexus/pull/799
