### PR TITLE
feat: bump nexus to 1.1.0

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "apollo-server": "^2.19.2",
-    "graphql": "^15.4.0",
-    "nexus": "^1.0.0",
-    "nexus-validate": "1.0.0-alpha.4",
-    "yup": "^0.32.8"
+    "graphql": "^15.5.3",
+    "nexus": "^1.1.0",
+    "nexus-validate": "^1.0.0",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "ts-node": "^9.1.1",

--- a/examples/hello-world/src/generated/nexus.ts
+++ b/examples/hello-world/src/generated/nexus.ts
@@ -4,8 +4,8 @@
  */
 
 
-import { Context } from "./../context"
-import { ValidateResolver } from "nexus-validate"
+import type { Context } from "./../context"
+import type { ValidateResolver } from "nexus-validate"
 
 
 
@@ -165,6 +165,8 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
+  }
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
   }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
     /**

--- a/examples/hello-world/src/schema.ts
+++ b/examples/hello-world/src/schema.ts
@@ -24,11 +24,7 @@ export const User = objectType({
     t.string('name');
     t.string('email');
     t.int('age');
-    t.string('website', {
-      validate: ({ string }) => ({
-        website: string().email().required(),
-      }),
-    });
+    t.string('website');
     t.string('secret');
     t.list.field('friends', {
       type: User,

--- a/examples/hello-world/yarn.lock
+++ b/examples/hello-world/yarn.lock
@@ -1014,10 +1014,15 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-graphql@^15.3.0, graphql@^15.4.0:
+graphql@^15.3.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
+
+graphql@^15.5.3:
+  version "15.5.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.3.tgz#c72349017d5c9f5446a897fe6908b3186db1da00"
+  integrity sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==
 
 has-symbols@^1.0.1:
   version "1.0.1"
@@ -1197,10 +1202,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-lodash-es@^4.17.11:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
-  integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
+lodash-es@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -1332,15 +1337,15 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-nexus-validate@1.0.0-alpha.4:
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/nexus-validate/-/nexus-validate-1.0.0-alpha.4.tgz#ba85de73f44f046e52e05e5e4f7efbe6c1f1e596"
-  integrity sha512-X1rxGyL4C14luEBdGclVROztZqEuyybhLnnDmIePSuPShMLOxKbNSqxG2bn/vtlVhp9sjtqHXRPZ/8r6AIIx+g==
-
-nexus@^1.0.0:
+nexus-validate@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/nexus/-/nexus-1.0.0.tgz#633b39abae1d7e9472ca40e37bb5d3e1263f6aa3"
-  integrity sha512-Toa91s9BJsX8pDX34QkOyKdnw8MmuOQkEboZMKSxvF9mWuAFkY74Zj1ssaexeV7yTQ7HoLQYUQ00FaWzXPmggQ==
+  resolved "https://registry.yarnpkg.com/nexus-validate/-/nexus-validate-1.0.0.tgz#2bb2291cecb7a3909b647b75fde1ab666ba39b95"
+  integrity sha512-wmshQH2etCIgZoIMCQeEXCrMPx+LknUhUFrVyfezJvnpO5c4MPBLlQQQQJ4VYn0cLRCckU+Pof290jVleVxSuw==
+
+nexus@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nexus/-/nexus-1.1.0.tgz#3d8fa05c29e7a61aa55f64ef5e0ba43dd76b3ed6"
+  integrity sha512-jUhbg22gKVY2YwZm726BrbfHaQ7Xzc0hNXklygDhuqaVxCuHCgFMhWa2svNWd1npe8kfeiu5nbwnz+UnhNXzCQ==
   dependencies:
     iterall "^1.3.0"
     tslib "^2.0.3"
@@ -1939,15 +1944,15 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-yup@^0.32.8:
-  version "0.32.8"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.8.tgz#16e4a949a86a69505abf99fd0941305ac9adfc39"
-  integrity sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==
+yup@^0.32.9:
+  version "0.32.9"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.9.tgz#9367bec6b1b0e39211ecbca598702e106019d872"
+  integrity sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==
   dependencies:
     "@babel/runtime" "^7.10.5"
     "@types/lodash" "^4.14.165"
     lodash "^4.17.20"
-    lodash-es "^4.17.11"
+    lodash-es "^4.17.15"
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "graphql": "^15.4.0",
-    "nexus": "^1.0.0",
-    "yup": "^0.32.8"
+    "graphql": "^15.x",
+    "nexus": "^1.1.0",
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { plugin } from 'nexus';
-import { printedGenTyping, printedGenTypingImport } from 'nexus/dist/core';
+import { printedGenTyping, printedGenTypingImport } from 'nexus/dist/utils';
 
 import { ValidatePluginErrorConfig, ValidationError } from './error';
 import { resolver } from './resolver';

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -5,6 +5,7 @@ import {
   MaybePromise,
   MiddlewareFn,
 } from 'nexus/dist/core';
+import { ValidationError } from 'yup';
 
 import { ObjectShape, rules, ValidationRules } from './rules';
 import { ValidatePluginConfig } from './index';
@@ -63,7 +64,8 @@ export const resolver = (validateConfig: ValidatePluginConfig = {}) => (
         await schema.validate(args);
       }
       return next(root, args, ctx, info);
-    } catch (error) {
+    } catch (_error) {
+      const error = _error as Error | ValidationError
       throw formatError({ error, args, ctx });
     }
   };


### PR DESCRIPTION
- Bump nexus to [1.1.0](https://github.com/graphql-nexus/nexus/releases/tag/1.1.0)
- Update graphql peer dependency
- Update some imports from nexus
- Update example project
